### PR TITLE
Add Folder for Q21 Onboarding Projects

### DIFF
--- a/onboarding/Q21/README.md
+++ b/onboarding/Q21/README.md
@@ -1,0 +1,3 @@
+# Q21 Onboarding Projects
+This folder contains the onboarding projects pursued by the electrical team
+in the Q21 season. The list of projects and their authors are given below:

--- a/onboarding/README.md
+++ b/onboarding/README.md
@@ -1,0 +1,4 @@
+# Onboarding Projects
+This folder contains the introductory PCB design projects used to help new and
+returning members of the electrical team get acquainted with Altium.
+The projects are sorted in sub directories corresponding to each season.


### PR DESCRIPTION
This pull request adds an onboarding folder to the repository with sub directories corresponding to each season. This should help keep everything organized and help us separate official mainline boards from onboarding projects. Onboarding projects for this year should be merged into the Q21 sub directory. There is also a README file in the Q21 directory where the designer can provide a quick description of their project and sign their name.