### PR TITLE
Remove Celestial Library from Git Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "libraries/jlcpcb-design-rules-stackups"]
 	path = libraries/jlcpcb-design-rules-stackups
 	url = https://github.com/ayberkozgur/jlcpcb-design-rules-stackups.git
-[submodule "libraries/altium-library"]
-	path = libraries/altium-library
-	url = https://github.com/issus/altium-library.git


### PR DESCRIPTION
Using a submodule for this library version locks it and adds extra complexity to the install. I think it makes the most sense to have team members download it elsewhere on their computers and follow the instructions given on the library website. Moreover, our documentation in the README already instructs users to follow the documentation from the Celestial library without any mention of the submodule.